### PR TITLE
Fix incorrect handling of nested objects

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -67,6 +67,7 @@ func (c *converter) convertBlock(block *hclsyntax.Block, out jsonObj) error {
 		} else {
 			obj := make(jsonObj)
 			out[key] = obj
+			out = obj
 		}
 		key = label
 	}

--- a/convert_test.go
+++ b/convert_test.go
@@ -46,9 +46,39 @@ locals {
 		%{if true ? false : true}"gotcha"\n%{else}4%{endif}
 	EOF
 }
+
+data "terraform_remote_state" "remote" {
+	backend = "s3"
+
+	config = {
+		profile = var.profile
+		region  = var.region
+		bucket  = "mybucket"
+		key     = "mykey"
+	}
+}
+
+variable "profile" {}
+
+variable "region" {
+	default = "us-east-1"
+}
 `
 
 const expectedJSON = `{
+	"data": {
+		"terraform_remote_state": {
+			"remote": {
+				"backend": "s3",
+				"config": {
+					"bucket": "mybucket",
+					"key": "mykey",
+					"profile": "${var.profile}",
+					"region": "${var.region}"
+				}
+			}
+		}
+	},
 	"locals": [
 		{
 			"arr": [
@@ -83,7 +113,13 @@ const expectedJSON = `{
 			"heredoc2": "\t\tAnother heredoc, that\n\t\tdoesn't remove indentation\n\t\t${local.other.3}\n\t\t%{if true ? false : true}\"gotcha\"\\n%{else}4%{endif}\n",
 			"simple": "${4 - 2}"
 		}
-	]
+	],
+	"variable": {
+		"profile": {},
+		"region": {
+			"default": "us-east-1"
+		}
+	}
 }`
 
 // Test that conversion works as expected


### PR DESCRIPTION
Nested objects are incorrectly put at the top-level in the output json.

Input HCL:
```
variable "aws_region" {
  default = "us-east-1"
}

variable "aws_profile" {
  default = "test"
}
```

Output before fix:
```
{
    "aws_region": {
        "default": "us-east-1"
    },
    "variable": {
        "aws_profile": {
            "default": "test"
        }
    }
}
```

Output after fix:
```
{
    "variable": {
        "aws_profile": {
            "default": "test"
        },
        "aws_region": {
            "default": "us-east-1"
        }
    }
}
```

Test case included.