### PR TITLE
Remove indentation from package

### DIFF
--- a/convert/convert.go
+++ b/convert/convert.go
@@ -39,12 +39,12 @@ func File(file *hcl.File, options Options) ([]byte, error) {
 		return nil, fmt.Errorf("convert file: %w", err)
 	}
 
-	fileBytes, err := json.MarshalIndent(convertedFile, "", "    ")
+	jsonBytes, err := json.Marshal(convertedFile)
 	if err != nil {
 		return nil, fmt.Errorf("marshal json: %w", err)
 	}
 
-	return fileBytes, nil
+	return jsonBytes, nil
 }
 
 type jsonObj map[string]interface{}
@@ -57,7 +57,7 @@ func convertFile(file *hcl.File, options Options) (jsonObj, error) {
 }
 
 type converter struct {
-	bytes []byte
+	bytes   []byte
 	options Options
 }
 


### PR DESCRIPTION
This PR moves the indentation of the JSON to the program itself inside of `main.go`. 

This allows the package to just focus on the conversion aspect and allow consumers to decide how they want to format the JSON, if at all.