### PR TITLE
Nil list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,9 @@ hcl2json
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+# Intellij
+.idea/
+
+# Golang vendor files
+vendor/

--- a/convert/convert.go
+++ b/convert/convert.go
@@ -146,7 +146,7 @@ func (c *converter) convertExpression(expr hclsyntax.Expression) (interface{}, e
 	case *hclsyntax.TemplateWrapExpr:
 		return c.convertExpression(value.Wrapped)
 	case *hclsyntax.TupleConsExpr:
-		var list []interface{}
+		list := make([]interface{}, 0)
 		for _, ex := range value.Exprs {
 			elem, err := c.convertExpression(ex)
 			if err != nil {


### PR DESCRIPTION
If given the following, list is incorrectly unmarshalled as `nil`.
In this example, `default` is set to `nil` rather than an empty list.

```
variable "a" {
  type = list(string)
  default = []
}
```

This PR fixes this issue.