### PR TITLE
Export convertFile

### DIFF
--- a/convert/convert.go
+++ b/convert/convert.go
@@ -34,7 +34,7 @@ func Bytes(bytes []byte, filename string, options Options) ([]byte, error) {
 
 // File takes an HCL file and converts it to its JSON representation.
 func File(file *hcl.File, options Options) ([]byte, error) {
-	convertedFile, err := convertFile(file, options)
+	convertedFile, err := ConvertFile(file, options)
 	if err != nil {
 		return nil, fmt.Errorf("convert file: %w", err)
 	}
@@ -54,7 +54,7 @@ type converter struct {
 	options Options
 }
 
-func convertFile(file *hcl.File, options Options) (jsonObj, error) {
+func ConvertFile(file *hcl.File, options Options) (jsonObj, error) {
 	body, ok := file.Body.(*hclsyntax.Body)
 	if !ok {
 		return nil, fmt.Errorf("convert file body to body type")


### PR DESCRIPTION
Export `convertFile` to `ConvertFile` to allow individuals to use the convert package to get structs/interfaces.

Currently the package can only be used to get a JSON string from HCL. This changes allows for getting the
jsonObj struct instead. Not sure if `jsonObj` needs to be exported, it doesn't seem to necessary so far, but happy
to update the PR if needed.