### PR TITLE
Don't wrap internal variable types into '${...}' string

### DIFF
--- a/convert/convert.go
+++ b/convert/convert.go
@@ -195,6 +195,13 @@ func (c *converter) convertExpression(expr hclsyntax.Expression) (interface{}, e
 		}
 		return m, nil
 	default:
+		val := c.rangeSource(expr.Range())
+		types := []string{"string", "number", "bool", "list", "set", "map", "object", "tuple"}
+		for _, t := range types {
+			if res := strings.HasPrefix(val, t); res {
+				return val, nil
+			}
+		}
 		return c.wrapExpr(expr), nil
 	}
 }


### PR DESCRIPTION
Trying to fix error

```
Error: Invalid type specification

  on cloud.tf.json line 480, in variable.auto_clean_known_host[0]:
 480:                 "type": "${bool}"

A type specification is either a primitive type keyword (bool, number, string)
or a complex type constructor call, like list(string).
```


Should be to correct parse with **terraform**, or **terrafrom console**
```
480:                 "type": "bool"
```