### PR TITLE
use type alias instead of a new type

### DIFF
--- a/convert/convert.go
+++ b/convert/convert.go
@@ -47,7 +47,7 @@ func File(file *hcl.File, options Options) ([]byte, error) {
 	return jsonBytes, nil
 }
 
-type jsonObj map[string]interface{}
+type jsonObj = map[string]interface{}
 
 type converter struct {
 	bytes   []byte


### PR DESCRIPTION
this way assertion like `object.(map[string]interface{})` will work and people will be able to use this as a library to parse HCL files into an object without extra JSON marshaling/unmarshaling, e.g.

```golang
file, _ := hclsyntax.ParseConfig(bytes, filename, hcl.Pos{Line: 1, Column: 1})
object, _ := convert.ConvertFile(file, convert.Options{Simplify: false})
```