### PR TITLE
Add apple silicone to build list

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,11 @@ jobs:
         arch:
           - "386"
           - amd64
+        include:
+          - os:
+              name: darwin
+              ext: ''
+            arch: "arm64"
         exclude:
           - os:
               name: darwin


### PR DESCRIPTION
Thanks for a useful tool! I just wanted to propose a small tweak here to the build process so that it outputs native binaries for Apple Silicone (M1 based macbooks).

I tested this out on my fork (see [this release](https://github.com/yorinasub17/hcl2json/releases/tag/v0.0.0-alpha.1)) and verified the `hcl2json` it generated works on my M1 MacBook Air.