### PR TITLE
Fix panic from invalid HCL when blocks are mixed with/without labels

### DIFF
--- a/convert/convert.go
+++ b/convert/convert.go
@@ -145,7 +145,13 @@ func (c *converter) convertBlock(block *hclsyntax.Block, out jsonObj) error {
 	// For consistency, always wrap the value in a collection.
 	// When multiple values are at the same key
 	if current, exists := out[key]; exists {
-		out[key] = append(current.([]interface{}), value)
+		switch currentTyped := current.(type) {
+		case []interface{}:
+			currentTyped = append(currentTyped, value)
+			out[key] = currentTyped
+		default:
+			return fmt.Errorf("invalid HCL detected for %q block, cannot have blocks with and without labels", key)
+		}
 	} else {
 		out[key] = []interface{}{value}
 	}

--- a/convert/convert_test.go
+++ b/convert/convert_test.go
@@ -3,6 +3,7 @@ package convert
 import (
 	"bytes"
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -281,6 +282,27 @@ func TestEndOfFileExpr(t *testing.T) {
 	}
 
 	compareTest(t, convertedBytes, expected)
+}
+
+func TestBlocksWithAndWithoutLabels(t *testing.T) {
+	input := `
+	foo "baz" {
+		key = 7
+		foo = "bar"
+	}
+
+	foo {
+		key = 7
+	}`
+
+	_, err := Bytes([]byte(input), "", Options{})
+	if err == nil {
+		t.Fatal("invalid HCL should have returned an error:", err)
+	}
+
+	if !strings.Contains(err.Error(), `invalid HCL detected for "foo" block, cannot have blocks with and without labels`) {
+		t.Fatalf("given error %q did not match expected error", err.Error())
+	}
 }
 
 func compareTest(t *testing.T, input []byte, expected string) {


### PR DESCRIPTION
This PR aims to fix a panic that was observed when parsing invalid HCL config. My understanding is that HCL blocks either have labels, or do not; you cannot mix these two concepts either, as there is no `optional` label.

Before the changes introduced in this PR, the following HCL config would cause a panic:

```hcl
foo "baz" {
  key = 7
  foo = "bar"
}

foo {
  key = 7
}
```

```console
panic: interface conversion: interface {} is convert.jsonObj, not []interface {}

goroutine 1 [running]:
github.com/tmccombs/hcl2json/convert.(*converter).convertBlock(0xc00019fd68, 0xc0001367e0, 0xc00016a870, 0x0, 0x0)
	/go/pkg/mod/github.com/tmccombs/hcl2json@v0.3.3/convert/convert.go:148 +0x6ef
github.com/tmccombs/hcl2json/convert.(*converter).convertBody(0xc00019fd68, 0xc00013a420, 0x0, 0x0, 0x0)
	/go/pkg/mod/github.com/tmccombs/hcl2json@v0.3.3/convert/convert.go:80 +0xb7
github.com/tmccombs/hcl2json/convert.ConvertFile(0xc000131900, 0x0, 0x0, 0xc000128288, 0x1)
	/go/pkg/mod/github.com/tmccombs/hcl2json@v0.3.3/convert/convert.go:68 +0x8d
github.com/tmccombs/hcl2json/convert.File(0xc000131900, 0x0, 0x0, 0x7ffd186d5e00, 0x49, 0x1, 0x1)
	/go/pkg/mod/github.com/tmccombs/hcl2json@v0.3.3/convert/convert.go:37 +0x38
github.com/tmccombs/hcl2json/convert.Bytes(0xc000178000, 0x69, 0x200, 0x7ffd186d5ead, 0x49, 0x0, 0x0, 0xc000102000, 0x7fb1ee7b4ca8, 0x1, ...)
	/go/pkg/mod/github.com/tmccombs/hcl2json@v0.3.3/convert/convert.go:27 +0xef
main.main()
	/go/pkg/mod/github.com/tmccombs/hcl2json@v0.3.3/main.go:34 +0x296
```

The root cause of the panic comes from an `interface{}` cast/type-assertion that is not checked:

https://github.com/tmccombs/hcl2json/blob/e18846d9ecec812d4c441aa7a384c79e505dc4d8/convert/convert.go#L148
