### PR TITLE
Read from stdin if no filenames are provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Upcoming
+
+- Make a few functions public in library
+- Fix bug where stdin wasn't used if no files are passed as arguments
+
 # 0.4.0
 - Update dependencies
 - Add support for passing multiple files to hcl2json

--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ func main() {
 		inputName = "COMPOSITE"
 	}
 
-	for _, filename := range flag.Args() {
+	for _, filename := range files {
 		var stream io.Reader
 		if filename == "-" {
 			stream = os.Stdin


### PR DESCRIPTION
0.4.0 introduced a bug where stdin was no longer read form if no
  arguments were supplied

Fixes: #62