### PR TITLE
fix typo in docker run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ $ hcl2json -simplify infile.hcl > out.json
 If you use the docker image, you can invoke with
 
 ```sh
-$ docker run -it --rm -v $PWD:/tmp tmmcombs/hcl2json /tmp/infile.hcl
+$ docker run -it --rm -v $PWD:/tmp tmccombs/hcl2json /tmp/infile.hcl
 ```
 
 ## Installation


### PR DESCRIPTION
You have a typo in your docker run command, fixing it so that it points to correct image.