### PR TITLE
chore(goreleaser): add `binary` to `formats` on Windows

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,7 +26,7 @@ archives:
     # use zip for windows archives
     format_overrides:
       - goos: windows
-        formats: [ 'zip' ]
+        formats: [ 'zip', 'binary' ]
     files:
       - LICENSE
       - README.md


### PR DESCRIPTION
Apply the following change to Windows as well.

- https://github.com/tmccombs/hcl2json/pull/120/commits/4ec60f1b7469c8206b090c6a48436d312e49e0e9

https://github.com/tmccombs/hcl2json/releases/tag/v0.6.7

<img width="341" alt="Image" src="https://github.com/user-attachments/assets/18175aba-af0f-4c5f-bc09-3cfc1268371d" />

I'm not sure whether this is expected or a bug, but `hcl2json_windows_amd64.zip` and `hcl2json_windows_arm64.zip` were released but `hcl2json_windows_amd64.exe` and `hcl2json_windows_arm64.exe` weren't released.

On the other hand, in case of macOS and Linux, both a raw binary and tarball were released.

e.g. `hcl2json_darwin_amd64` and `hcl2json_darwin_amd64.tar.gz`

## Background

- https://github.com/aquaproj/aqua-registry/pull/33808

aqua supports hcl2json, but it failed to install hcl2json v0.6.7 on Windows as `hcl2json_windows_amd64.exe` and `hcl2json_windows_arm64.exe` weren't released.