### PR TITLE
Re-support arm64 architecture

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,6 +15,9 @@ builds:
       - linux
       - windows
       - darwin
+    goarch:
+      - amd64
+      - arm64
 
 archives:
   - formats: [ 'tar.gz', 'binary' ]
@@ -33,10 +36,11 @@ archives:
 
 dockers:
   - image_templates:
-    - "tmccombs/{{ .ProjectName }}:latest"
-    - "tmccombs/{{ .ProjectName }}:{{ .Version }}"
-    - "tmccombs/{{ .ProjectName }}:{{ .Major }}.{{ .Minor }}"
+    - "tmccombs/{{ .ProjectName }}:{{ .Version }}-amd64"
+    goos: linux
+    goarch: amd64
     build_flag_templates:
+      - "--platform=linux/amd64"
       - "--label=org.opencontainers.image.title={{ .ProjectName }}"
       - "--label=org.opencontainers.image.description=Convert HCL to JSON"
       - "--label=org.opencontainers.image.url=https://github.com/tmccombs/hcl2json"
@@ -45,6 +49,34 @@ dockers:
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
       - "--label=org.opencontainers.image.created={{ .Date }}"
       - "--label=org.opencontainers.image.licenses=Apache-2.0"
+  - image_templates:
+    - "tmccombs/{{ .ProjectName }}:{{ .Version }}-arm64"
+    goos: linux
+    goarch: arm64
+    build_flag_templates:
+      - "--platform=linux/arm64"
+      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
+      - "--label=org.opencontainers.image.description=Convert HCL to JSON"
+      - "--label=org.opencontainers.image.url=https://github.com/tmccombs/hcl2json"
+      - "--label=org.opencontainers.image.source=https://github.com/tmccombs/hcl2json"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.created={{ .Date }}"
+      - "--label=org.opencontainers.image.licenses=Apache-2.0"
+
+docker_manifests:
+  - name_template: "tmccombs/{{ .ProjectName }}:{{ .Version }}"
+    image_templates:
+      - "tmccombs/{{ .ProjectName }}:{{ .Version }}-amd64"
+      - "tmccombs/{{ .ProjectName }}:{{ .Version }}-arm64"
+  - name_template: "tmccombs/{{ .ProjectName }}:{{ .Major }}.{{ .Minor }}"
+    image_templates:
+      - "tmccombs/{{ .ProjectName }}:{{ .Version }}-amd64"
+      - "tmccombs/{{ .ProjectName }}:{{ .Version }}-arm64"
+  - name_template: "tmccombs/{{ .ProjectName }}:latest"
+    image_templates:
+      - "tmccombs/{{ .ProjectName }}:{{ .Version }}-amd64"
+      - "tmccombs/{{ .ProjectName }}:{{ .Version }}-arm64"
 
 
 changelog:


### PR DESCRIPTION
It enables pushing arm64 images to Docker Hub.

Since switching to GoReleaser for Docker image releases in https://github.com/tmccombs/hcl2json/commit/adead17b4f5db0106a26006dfc9bea57f214bebb, arm64 images are no longer being pushed to Docker Hub.

- https://hub.docker.com/r/tmccombs/hcl2json/tags

I use hcl2json on arm64 architecture and would appreciate arm64 support. Currently, I'm using version 0.6.5 by specifying it directly.

Please review this PR.